### PR TITLE
Noncrucial dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
         <dependency>
             <groupId>eu.erasmuswithoutpaper</groupId>
             <artifactId>ewp-registry-client</artifactId>
-            <version>1.7.0</version>
+            <version>1.8.0</version>
         </dependency>
         <dependency>
             <groupId>net.adamcin.httpsig</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>4.4.0.201606070830-r</version>
+            <version>4.11.9.201909030838-r</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.5.1</version>
+            <version>3.22.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.57</version>
+            <version>1.70</version>
         </dependency>
         <dependency>
             <groupId>eu.erasmuswithoutpaper</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>org.ocpsoft.prettytime</groupId>
             <artifactId>prettytime</artifactId>
-            <version>4.0.1.Final</version>
+            <version>4.0.6.Final</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>


### PR DESCRIPTION
* Update Jgit dependency (4.4.0 -> 4.11.9)
* Update BouncyCastle dependency (1.57 -> 1.70) (security)
* Small update of prettytime dependency (4.0.1 -> 4.0.6)
* Update ewp-registry-client dependecy (1.7.0 -> 1.8.0)
* Update AssertJ dependency (3.5.1 -> 3.22) (security)
