### PR TITLE
Update Spring Boot Starter parent (1.5.6 -> 1.5.22)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.6.RELEASE</version>
+        <version>1.5.22.RELEASE</version>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
Probably the last update for 1.5.X branch.

(The next step should be upgrading all to Spring Boot 2.)