### PR TITLE
Jaxb2 Maven Plugin update from 2.4 to 2.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>jaxb2-maven-plugin</artifactId>
-                <version>2.4</version>
+                <version>2.5.0</version>
                 <executions>
                     <execution>
                         <id>xjc</id>


### PR DESCRIPTION
Version 2.5.0 adds support for Java 11 (so the build stops failing on J11).